### PR TITLE
Add onboarding guide for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
-# bookish-chainsaw
-odns
+# Workplace Operations Dashboard
+
+A lightweight, framework-free dashboard that highlights the health of workplace teams. It
+summarises metrics, trend lines, upcoming meetings, and narrative highlights across
+Operations, Engineering, People Operations, and Workplace Experience departments.
+
+## Getting Started
+
+The dashboard runs entirely in the browser without a build step. You can open `index.html`
+directly or serve it from a simple static HTTP server for local development.
+
+### Option 1: Open the HTML file directly
+
+1. Double-click `index.html` (or open it via your browser’s `File > Open` menu).
+2. All functionality works offline because the data is embedded in `src/data.js`.
+
+### Option 2: Serve with Python (recommended for local iteration)
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit [http://localhost:8000](http://localhost:8000) and navigate to
+`index.html`.
+
+### Option 3: Use `npx serve`
+
+If you have Node.js installed:
+
+```bash
+npx serve .
+```
+
+## Project Structure
+
+```
+├── assets/
+│   └── styles.css        # Global styling for layout, cards, and charts
+├── index.html            # Page shell with layout and semantic structure
+├── src/
+│   ├── data.js           # Sample data describing each department
+│   └── main.js           # UI rendering + interactivity (filters, charts)
+```
+
+### Further Reading
+
+New contributors should start with [`docs/ONBOARDING.md`](docs/ONBOARDING.md) for a tour of
+the codebase, data flow, and suggested next steps.
+
+## Customising the Dashboard
+
+* Update `src/data.js` to reflect real metrics, project summaries, highlights, and
+  meetings from your workplace systems.
+* Adjust the cards or layout in `index.html` to match the views your stakeholders need
+  most (e.g. swap projects for staffing forecasts).
+* Tweak the palette or component styling in `assets/styles.css` to align with brand
+  guidelines.
+
+## Next Ideas
+
+* Wire up real APIs or CSV exports by replacing the static data module with fetch calls.
+* Add authentication and role-based views once you host it behind a lightweight backend.
+* Introduce charts (e.g. with D3 or Chart.js) for richer visuals or historical analysis.
+
+## Testing
+
+There are no automated tests yet. Visual inspection in the browser ensures the layout and
+interactions behave as expected across screen sizes.

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,345 @@
+:root {
+  color-scheme: light;
+  --color-background: #f6f7fb;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f0f1f7;
+  --color-border: #d8dbe7;
+  --color-text: #1f2937;
+  --color-muted: #6b7280;
+  --color-accent: #2563eb;
+  --color-accent-muted: #bfdbfe;
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  --shadow-sm: 0 8px 24px rgba(15, 23, 42, 0.04);
+  --shadow-md: 0 20px 45px rgba(15, 23, 42, 0.08);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--color-background);
+  color: var(--color-text);
+  line-height: 1.5;
+}
+
+.dashboard {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 32px 56px;
+}
+
+.dashboard__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+.dashboard__header h1 {
+  font-size: 2rem;
+  margin: 0 0 8px;
+}
+
+.dashboard__subtitle {
+  margin: 0;
+  color: var(--color-muted);
+  max-width: 560px;
+}
+
+.dashboard__meta {
+  display: flex;
+  gap: 24px;
+}
+
+.meta__item {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface);
+  padding: 16px 20px;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  min-width: 180px;
+}
+
+.meta__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+  margin-bottom: 6px;
+}
+
+.meta__value {
+  font-weight: 600;
+}
+
+.dashboard__main {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 32px;
+}
+
+.dashboard__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.dashboard__content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+}
+
+.card--narrow {
+  padding-bottom: 12px;
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.card__context {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.filter__label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.filter__select {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.filter__hint {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+  margin-top: 12px;
+}
+
+.grid {
+  display: grid;
+  gap: 18px;
+}
+
+.grid--stats {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.grid--split {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 18px 20px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-alt);
+}
+
+.stat-card__label {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.stat-card__value {
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.stat-card__trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.stat-card__trend span {
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--color-accent);
+}
+
+.trend-chart {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 12px;
+  align-items: end;
+  height: 180px;
+}
+
+.trend-chart__bar {
+  position: relative;
+  background: linear-gradient(180deg, var(--color-accent) 0%, #60a5fa 100%);
+  border-radius: 12px 12px 4px 4px;
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.trend-chart__bar::after {
+  content: attr(data-label);
+  position: absolute;
+  bottom: -28px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.trend-chart__value {
+  position: absolute;
+  top: -28px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text);
+  background: var(--color-surface);
+  padding: 4px 8px;
+  border-radius: 999px;
+  box-shadow: var(--shadow-sm);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.list__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.list__content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.list__title {
+  font-weight: 600;
+}
+
+.list__subtitle {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.list__meta {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-accent);
+}
+
+.meetings {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.meeting {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 0 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.meeting:last-child {
+  border-bottom: none;
+}
+
+.meeting__title {
+  font-weight: 600;
+}
+
+.meeting__meta {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.dashboard__footer {
+  margin: 48px auto 0;
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+  max-width: 620px;
+}
+
+@media (max-width: 960px) {
+  .dashboard {
+    padding: 24px 20px 48px;
+  }
+
+  .dashboard__main {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dashboard__meta {
+    width: 100%;
+  }
+
+  .meta__item {
+    flex: 1;
+  }
+}
+
+@media (max-width: 600px) {
+  .dashboard__meta {
+    flex-direction: column;
+  }
+
+  .meta__item {
+    width: 100%;
+  }
+
+  .trend-chart {
+    height: 160px;
+  }
+
+  .stat-card__value {
+    font-size: 1.6rem;
+  }
+}

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,88 @@
+# Workplace Operations Dashboard Onboarding Guide
+
+Welcome to the Workplace Operations Dashboard project! This guide gives newcomers a
+quick orientation to the codebase, explains how data flows through the application,
+and highlights next areas to explore as you start contributing.
+
+## Repository Layout
+
+The project is intentionally lightweight—everything required to render the dashboard
+lives in a handful of files:
+
+```
+├── index.html         # Semantic page shell and mount points
+├── assets/
+│   └── styles.css     # Global look-and-feel, layout, and component styles
+├── src/
+│   ├── data.js        # Source-of-truth metrics for each department
+│   └── main.js        # Client-side rendering + interactivity layer
+└── docs/
+    └── ONBOARDING.md  # You are here
+```
+
+Because the site is completely static, there is no build tooling or dependency
+installation required—opening `index.html` in a modern browser will execute the app.
+
+## How the Dashboard Renders
+
+1. **HTML skeleton (`index.html`)**
+   * Defines the structural regions (header, sidebar, content area, footer).
+   * Provides empty containers (`<section id="stats-grid">`, `<ul id="projects-list">`,
+     etc.) that JavaScript later populates with department-specific data.
+   * Loads the stylesheet and the JavaScript entry point (`src/main.js`).
+
+2. **Styling layer (`assets/styles.css`)**
+   * Implements a responsive CSS grid layout so the dashboard adapts from desktop to
+     tablet widths.
+   * Encapsulates reusable component classes (cards, statistic tiles, lists, trend chart)
+     that the renderer applies when it constructs DOM elements.
+   * Sets the overall visual system: typography, color palette, shadows, and spacing.
+
+3. **Data module (`src/data.js`)**
+   * Exports a single `departments` array. Each department object follows a consistent
+     shape (metrics, trend, projects, highlights, meetings).
+   * Updating this file is the fastest way to swap in real metrics or curate a different
+     narrative for each team while the rest of the UI logic remains unchanged.
+
+4. **Rendering logic (`src/main.js`)**
+   * Imports the `departments` data and caches references to all mount points in the DOM.
+   * Populates the department selector (`<select>`) from the data array during
+     initialization.
+   * Contains small renderer functions for each dashboard section (statistics cards,
+     trend chart, projects list, highlights list, and meetings sidebar). Each renderer
+     receives the current department object and updates only its slice of the UI.
+   * Tracks the currently selected department via the dropdown’s change event and re-runs
+     all renderers whenever the selection changes.
+
+The renderers operate on plain DOM APIs rather than a framework so it is easy to follow
+what happens. When a department is selected, the code clears existing child nodes in each
+section and rebuilds the markup based on the new data set.
+
+## Key Concepts to Understand
+
+* **Data contracts** – Every department entry in `src/data.js` must provide the fields
+  the renderers expect (`metrics`, `trend.datapoints`, `projects.items`, etc.). Keeping
+  that schema stable ensures the UI will remain consistent.
+* **Formatting helpers** – `formatValue` in `src/main.js` centralizes how numbers are
+  displayed (thousands separators, percentage suffixes, minimum bar height), so extending
+  the formatter is safer than sprinkling formatting logic across renderers.
+* **Accessibility considerations** – The dashboard uses semantic HTML landmarks,
+  provides `aria-label` attributes for chart regions, and sets text equivalents for data
+  so screen readers can interpret the content. Continue that pattern for new components.
+
+## Suggested Next Steps for Contributors
+
+1. **Automate quality checks** – Introduce tooling such as Prettier, ESLint, or stylelint
+   to enforce formatting and catch common issues before committing changes.
+2. **Add tests** – Consider wiring up lightweight DOM snapshot tests (e.g., with Vitest or
+   Jest + jsdom) to validate that renderer functions output the expected structures when
+   data changes.
+3. **Connect real data sources** – Replace the static data module with fetch calls to an
+   internal API or CSV export so the dashboard reflects live information.
+4. **Enhance visuals** – Explore integrating a charting library for more sophisticated
+   trend visualizations or add drill-down views per metric card.
+5. **Document contribution workflows** – Expand the README with coding standards,
+   branching strategy, and review guidelines as the team grows.
+
+Welcome aboard, and feel free to reach out to the maintainers if anything in this guide is
+unclear or if you have ideas for improvements!

--- a/index.html
+++ b/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Workplace Operations Dashboard</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="dashboard">
+      <header class="dashboard__header">
+        <div>
+          <h1>Workplace Operations Dashboard</h1>
+          <p class="dashboard__subtitle">
+            A unified view of team health, project delivery, and operational focus.
+          </p>
+        </div>
+        <div class="dashboard__meta">
+          <div class="meta__item">
+            <span class="meta__label">Reporting Period</span>
+            <span class="meta__value" id="reporting-period">Week 32 · 2024</span>
+          </div>
+          <div class="meta__item">
+            <span class="meta__label">Last Synced</span>
+            <span class="meta__value" id="last-synced">15 minutes ago</span>
+          </div>
+        </div>
+      </header>
+
+      <main class="dashboard__main">
+        <aside class="dashboard__sidebar">
+          <section class="card">
+            <h2>Focus Filter</h2>
+            <label for="department-select" class="filter__label"
+              >Department</label
+            >
+            <select id="department-select" class="filter__select"></select>
+            <p class="filter__hint">
+              Explore how each department is tracking against this week’s operational
+              targets.
+            </p>
+          </section>
+
+          <section class="card card--narrow">
+            <h2>Upcoming Meetings</h2>
+            <ul id="meetings-list" class="meetings"></ul>
+          </section>
+        </aside>
+
+        <section class="dashboard__content">
+          <section class="grid grid--stats" id="stats-grid"></section>
+
+          <section class="card">
+            <div class="card__header">
+              <h2>Weekly Delivery Trend</h2>
+              <span class="card__context" id="trend-context"></span>
+            </div>
+            <div id="trend-chart" class="trend-chart" role="img" aria-label="Weekly delivery trend chart"></div>
+          </section>
+
+          <section class="grid grid--split">
+            <div class="card">
+              <div class="card__header">
+                <h2>Key Initiatives</h2>
+                <span class="card__context" id="projects-context"></span>
+              </div>
+              <ul id="projects-list" class="list list--projects"></ul>
+            </div>
+
+            <div class="card">
+              <div class="card__header">
+                <h2>Team Highlights</h2>
+                <span class="card__context" id="highlights-context"></span>
+              </div>
+              <ul id="highlights-list" class="list list--highlights"></ul>
+            </div>
+          </section>
+        </section>
+      </main>
+    </div>
+
+    <footer class="dashboard__footer">
+      <p>
+        Built for transparent operations. Data refreshes every 15 minutes from our
+        project tracker, HRIS, and facilities telemetry.
+      </p>
+    </footer>
+
+    <script type="module" src="src/main.js"></script>
+  </body>
+</html>

--- a/src/data.js
+++ b/src/data.js
@@ -1,0 +1,447 @@
+export const departments = [
+  {
+    id: "all",
+    name: "All Departments",
+    summary: "Aggregate performance across operations, engineering, people, and workplace teams.",
+    metrics: [
+      {
+        label: "Projects On Track",
+        value: 18,
+        suffix: "/ 22",
+        trend: { label: "↑ 3", description: "vs last week" }
+      },
+      {
+        label: "Team Health Score",
+        value: 8.7,
+        suffix: "/ 10",
+        trend: { label: "↗ 0.4", description: "steady improvement" }
+      },
+      {
+        label: "Average Cycle Time",
+        value: 4.2,
+        suffix: " days",
+        trend: { label: "↓ 0.5", description: "faster than target" }
+      },
+      {
+        label: "Office Utilization",
+        value: 68,
+        suffix: "%",
+        trend: { label: "↑ 6", description: "after new seating plan" }
+      }
+    ],
+    trend: {
+      context: "Story points delivered across all teams",
+      datapoints: [
+        { label: "Mon", value: 54 },
+        { label: "Tue", value: 62 },
+        { label: "Wed", value: 71 },
+        { label: "Thu", value: 64 },
+        { label: "Fri", value: 78 },
+        { label: "Sat", value: 46 },
+        { label: "Sun", value: 38 }
+      ]
+    },
+    projects: {
+      context: "Top initiatives with the biggest operational impact",
+      items: [
+        {
+          title: "Hybrid Work Enablement",
+          subtitle: "Deploy desk booking analytics to refine occupancy targets",
+          meta: "Phase 2 · 76% complete"
+        },
+        {
+          title: "Incident Response Playbooks",
+          subtitle: "Cross-functional tabletop run-through with leadership",
+          meta: "Pilot sessions wrap Friday"
+        },
+        {
+          title: "Benefits Enrollment Refresh",
+          subtitle: "Coordinated HR + Finance comms and knowledge base articles",
+          meta: "Launch comms Tuesday"
+        }
+      ]
+    },
+    highlights: {
+      context: "Wins and risks surfaced in leadership sync",
+      items: [
+        {
+          title: "Engineering shipped the deployment guardrails ahead of schedule",
+          subtitle: "Early telemetry shows 32% fewer rollbacks",
+          meta: "Reliability"
+        },
+        {
+          title: "Facilities resolved HVAC drift in the north annex",
+          subtitle: "Comfort scores climbed 12 points overnight",
+          meta: "Environment"
+        },
+        {
+          title: "People Ops onboarding cohort reached 95% satisfaction",
+          subtitle: "New check-in template surfaced friction points earlier",
+          meta: "People"
+        }
+      ]
+    },
+    meetings: [
+      {
+        title: "Operations Council",
+        description: "Weekly alignment on department OKRs",
+        time: "Monday · 9:00 – 10:00"
+      },
+      {
+        title: "Workplace Experience Deep Dive",
+        description: "Final seating map review for Q4",
+        time: "Tuesday · 14:30 – 15:15"
+      },
+      {
+        title: "People Ops Pulse",
+        description: "Review sentiment survey themes",
+        time: "Thursday · 11:00 – 11:45"
+      }
+    ]
+  },
+  {
+    id: "ops",
+    name: "Operations",
+    summary: "Ensuring end-to-end processes remain resilient and measurable.",
+    metrics: [
+      {
+        label: "On-Time Deliveries",
+        value: 96,
+        suffix: "%",
+        trend: { label: "↑ 2", description: "after vendor workshop" }
+      },
+      {
+        label: "Escalations",
+        value: 3,
+        suffix: " open",
+        trend: { label: "↓ 1", description: "major incidents resolved" }
+      },
+      {
+        label: "Budget Burn",
+        value: 51,
+        suffix: "%",
+        trend: { label: "↔", description: "mid-quarter" }
+      },
+      {
+        label: "Automation Coverage",
+        value: 64,
+        suffix: "%",
+        trend: { label: "↑ 8", description: "three new playbooks" }
+      }
+    ],
+    trend: {
+      context: "Fulfillment cycle time (hours per request)",
+      datapoints: [
+        { label: "Mon", value: 5.1 },
+        { label: "Tue", value: 4.8 },
+        { label: "Wed", value: 4.3 },
+        { label: "Thu", value: 4.6 },
+        { label: "Fri", value: 3.9 },
+        { label: "Sat", value: 4.4 },
+        { label: "Sun", value: 4.2 }
+      ]
+    },
+    projects: {
+      context: "Process optimizations nearing completion",
+      items: [
+        {
+          title: "Vendor SLA Dashboard",
+          subtitle: "Unified uptime visibility across logistics partners",
+          meta: "Go-live Friday"
+        },
+        {
+          title: "Auto-Renewal Policy",
+          subtitle: "Legal + Ops review to trim manual paperwork",
+          meta: "Sign-off pending"
+        }
+      ]
+    },
+    highlights: {
+      context: "Signals from the operations command center",
+      items: [
+        {
+          title: "Escalation runbook adoption hit 92% compliance",
+          subtitle: "Team ran two successful failover drills",
+          meta: "Operational Excellence"
+        },
+        {
+          title: "Warehouse IoT rollout expanded to 3 new sites",
+          subtitle: "Cycle time variance cut by 18%",
+          meta: "Automation"
+        }
+      ]
+    },
+    meetings: [
+      {
+        title: "Logistics Vendor Sync",
+        description: "Spot-check SLA performance",
+        time: "Wednesday · 13:00 – 13:45"
+      },
+      {
+        title: "Quarterly Risk Review",
+        description: "Scenario modeling for peak season",
+        time: "Friday · 10:30 – 12:00"
+      }
+    ]
+  },
+  {
+    id: "eng",
+    name: "Engineering",
+    summary: "Delivering reliable product increments and platform improvements.",
+    metrics: [
+      {
+        label: "Deployment Success",
+        value: 99.1,
+        suffix: "%",
+        trend: { label: "↑ 1.2", description: "release guardrails live" }
+      },
+      {
+        label: "Velocity",
+        value: 420,
+        suffix: " pts",
+        trend: { label: "↑ 28", description: "productive spike" }
+      },
+      {
+        label: "Open Bugs",
+        value: 47,
+        suffix: "",
+        trend: { label: "↓ 12", description: "triage blitz" }
+      },
+      {
+        label: "Incident MTTR",
+        value: 42,
+        suffix: " mins",
+        trend: { label: "↓ 9", description: "faster mitigations" }
+      }
+    ],
+    trend: {
+      context: "Story points completed per day",
+      datapoints: [
+        { label: "Mon", value: 68 },
+        { label: "Tue", value: 74 },
+        { label: "Wed", value: 82 },
+        { label: "Thu", value: 71 },
+        { label: "Fri", value: 89 },
+        { label: "Sat", value: 36 },
+        { label: "Sun", value: 28 }
+      ]
+    },
+    projects: {
+      context: "Focus areas for the platform team",
+      items: [
+        {
+          title: "Observability Unification",
+          subtitle: "Migrating service metrics into the shared timeline view",
+          meta: "84% complete"
+        },
+        {
+          title: "API Rate Guardrails",
+          subtitle: "Progressive throttling + customer comms",
+          meta: "ETA next sprint"
+        },
+        {
+          title: "Mobile Shell Refresh",
+          subtitle: "Final QA for new offline persistence",
+          meta: "Ship window Wednesday"
+        }
+      ]
+    },
+    highlights: {
+      context: "Notable engineering callouts",
+      items: [
+        {
+          title: "Launch readiness checklist adopted squad-wide",
+          subtitle: "Defects at launch dipped 22%",
+          meta: "Quality"
+        },
+        {
+          title: "Error budget trending within safe limits",
+          subtitle: "SLO burn-down recovered after patch",
+          meta: "Reliability"
+        }
+      ]
+    },
+    meetings: [
+      {
+        title: "Architecture Review Board",
+        description: "Sequence-based caching proposal",
+        time: "Tuesday · 16:00 – 17:00"
+      },
+      {
+        title: "Incident Game Day",
+        description: "Chaos workflow validation",
+        time: "Thursday · 15:00 – 16:30"
+      }
+    ]
+  },
+  {
+    id: "people",
+    name: "People Operations",
+    summary: "Supporting employee engagement, hiring velocity, and retention.",
+    metrics: [
+      {
+        label: "Hiring Pipeline",
+        value: 42,
+        suffix: " open reqs",
+        trend: { label: "↗ 4", description: "marketing pipeline expanding" }
+      },
+      {
+        label: "Time to Fill",
+        value: 27,
+        suffix: " days",
+        trend: { label: "↓ 3", description: "streamlined interviews" }
+      },
+      {
+        label: "Attrition",
+        value: 6.4,
+        suffix: "%",
+        trend: { label: "↘ 0.8", description: "lowest this year" }
+      },
+      {
+        label: "Pulse Score",
+        value: 8.9,
+        suffix: "/ 10",
+        trend: { label: "↑ 0.6", description: "new manager rituals" }
+      }
+    ],
+    trend: {
+      context: "Offer acceptance rate per weekday",
+      datapoints: [
+        { label: "Mon", value: 78 },
+        { label: "Tue", value: 82 },
+        { label: "Wed", value: 74 },
+        { label: "Thu", value: 76 },
+        { label: "Fri", value: 88 },
+        { label: "Sat", value: 0 },
+        { label: "Sun", value: 0 }
+      ]
+    },
+    projects: {
+      context: "Employee experience efforts in flight",
+      items: [
+        {
+          title: "Manager Toolkit 2.0",
+          subtitle: "Peer coaching, conflict resolution, and salary narrative",
+          meta: "Workshop sprint this week"
+        },
+        {
+          title: "Global Onboarding Journey",
+          subtitle: "Localized benefits library launch",
+          meta: "Feedback review Friday"
+        }
+      ]
+    },
+    highlights: {
+      context: "Signals from the employee lifecycle",
+      items: [
+        {
+          title: "New hire NPS hit 76",
+          subtitle: "Welcome mentors credited for the lift",
+          meta: "Engagement"
+        },
+        {
+          title: "Benefits FAQ traffic tripled post campaign",
+          subtitle: "Self-serve answers reduced ticket queue by 18%",
+          meta: "Enablement"
+        }
+      ]
+    },
+    meetings: [
+      {
+        title: "Compensation Council",
+        description: "Finalize mid-year adjustments",
+        time: "Monday · 11:00 – 12:00"
+      },
+      {
+        title: "Talent Marketing Sync",
+        description: "Campaign retrospectives + next sprint",
+        time: "Wednesday · 15:30 – 16:15"
+      }
+    ]
+  },
+  {
+    id: "workplace",
+    name: "Workplace Experience",
+    summary: "Creating an environment where people do their best work.",
+    metrics: [
+      {
+        label: "Occupancy",
+        value: 71,
+        suffix: "%",
+        trend: { label: "↑ 5", description: "neighborhood pilot" }
+      },
+      {
+        label: "Support Tickets",
+        value: 18,
+        suffix: " open",
+        trend: { label: "↘ 4", description: "self-serve kiosks live" }
+      },
+      {
+        label: "Satisfaction",
+        value: 9.1,
+        suffix: "/ 10",
+        trend: { label: "↑ 0.7", description: "community activations" }
+      },
+      {
+        label: "Energy Use",
+        value: 84,
+        suffix: "% of baseline",
+        trend: { label: "↓ 6", description: "HVAC tuning complete" }
+      }
+    ],
+    trend: {
+      context: "Daily foot traffic (badge entries)",
+      datapoints: [
+        { label: "Mon", value: 420 },
+        { label: "Tue", value: 468 },
+        { label: "Wed", value: 492 },
+        { label: "Thu", value: 476 },
+        { label: "Fri", value: 388 },
+        { label: "Sat", value: 160 },
+        { label: "Sun", value: 120 }
+      ]
+    },
+    projects: {
+      context: "Facilities improvements in focus",
+      items: [
+        {
+          title: "Wayfinding Refresh",
+          subtitle: "Install dynamic signage and floor beacons",
+          meta: "Installations ongoing"
+        },
+        {
+          title: "Wellness Room Expansion",
+          subtitle: "Ergonomic upgrades and booking automation",
+          meta: "Contractor review Thursday"
+        }
+      ]
+    },
+    highlights: {
+      context: "Stories from the workplace experience team",
+      items: [
+        {
+          title: "Community garden lunches filled every seat",
+          subtitle: "Employee chef program piloted successfully",
+          meta: "Engagement"
+        },
+        {
+          title: "Air quality monitoring alerts now integrated",
+          subtitle: "Facilities team receives push notifications",
+          meta: "Safety"
+        }
+      ]
+    },
+    meetings: [
+      {
+        title: "Space Planning Huddle",
+        description: "Re-balance quiet vs collaborative zones",
+        time: "Tuesday · 10:00 – 10:45"
+      },
+      {
+        title: "Vendor Walkthrough",
+        description: "Review signage installation progress",
+        time: "Thursday · 09:30 – 10:15"
+      }
+    ]
+  }
+];

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,170 @@
+import { departments } from "./data.js";
+
+const departmentSelect = document.querySelector("#department-select");
+const statsGrid = document.querySelector("#stats-grid");
+const trendChart = document.querySelector("#trend-chart");
+const trendContext = document.querySelector("#trend-context");
+const projectsList = document.querySelector("#projects-list");
+const projectsContext = document.querySelector("#projects-context");
+const highlightsList = document.querySelector("#highlights-list");
+const highlightsContext = document.querySelector("#highlights-context");
+const meetingsList = document.querySelector("#meetings-list");
+
+const formatValue = (value) => {
+  if (typeof value === "number" && value >= 1000) {
+    return value.toLocaleString();
+  }
+
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return value.toString();
+  }
+
+  if (typeof value === "number") {
+    return value.toLocaleString(undefined, { maximumFractionDigits: 1 });
+  }
+
+  return value;
+};
+
+const populateDepartmentSelect = () => {
+  departments.forEach((dept) => {
+    const option = document.createElement("option");
+    option.value = dept.id;
+    option.textContent = dept.name;
+    departmentSelect.append(option);
+  });
+};
+
+const renderStats = (dept) => {
+  statsGrid.innerHTML = "";
+
+  dept.metrics.forEach((metric) => {
+    const card = document.createElement("article");
+    card.className = "stat-card";
+
+    const label = document.createElement("span");
+    label.className = "stat-card__label";
+    label.textContent = metric.label;
+
+    const value = document.createElement("strong");
+    value.className = "stat-card__value";
+    value.textContent = `${formatValue(metric.value)}${metric.suffix ?? ""}`;
+
+    const trend = document.createElement("span");
+    trend.className = "stat-card__trend";
+    trend.innerHTML = `<span>${metric.trend.label}</span>${metric.trend.description}`;
+
+    card.append(label, value, trend);
+    statsGrid.append(card);
+  });
+};
+
+const renderTrend = (dept) => {
+  const datapoints = dept.trend.datapoints;
+  const maxValue = Math.max(...datapoints.map((point) => point.value));
+
+  trendContext.textContent = dept.trend.context;
+  trendChart.innerHTML = "";
+
+  datapoints.forEach((point) => {
+    const bar = document.createElement("div");
+    bar.className = "trend-chart__bar";
+    bar.dataset.label = point.label;
+
+    const height = maxValue === 0 ? 0 : (point.value / maxValue) * 100;
+    bar.style.height = `${Math.max(height, 8)}%`;
+
+    const value = document.createElement("span");
+    value.className = "trend-chart__value";
+    value.textContent = formatValue(point.value);
+
+    bar.append(value);
+    trendChart.append(bar);
+  });
+};
+
+const renderList = (container, items) => {
+  container.innerHTML = "";
+  items.forEach((item) => {
+    const li = document.createElement("li");
+    li.className = "list__item";
+
+    const content = document.createElement("div");
+    content.className = "list__content";
+
+    const title = document.createElement("span");
+    title.className = "list__title";
+    title.textContent = item.title;
+
+    const subtitle = document.createElement("span");
+    subtitle.className = "list__subtitle";
+    subtitle.textContent = item.subtitle;
+
+    content.append(title, subtitle);
+
+    const meta = document.createElement("span");
+    meta.className = "list__meta";
+    meta.textContent = item.meta;
+
+    li.append(content, meta);
+    container.append(li);
+  });
+};
+
+const renderMeetings = (dept) => {
+  meetingsList.innerHTML = "";
+  dept.meetings.forEach((meeting) => {
+    const item = document.createElement("li");
+    item.className = "meeting";
+
+    const title = document.createElement("span");
+    title.className = "meeting__title";
+    title.textContent = meeting.title;
+
+    const description = document.createElement("span");
+    description.className = "meeting__meta";
+    description.textContent = meeting.description;
+
+    const time = document.createElement("span");
+    time.className = "meeting__meta";
+    time.textContent = meeting.time;
+
+    item.append(title, description, time);
+    meetingsList.append(item);
+  });
+};
+
+const setContexts = (dept) => {
+  projectsContext.textContent = dept.projects.context;
+  highlightsContext.textContent = dept.highlights.context;
+};
+
+const renderDepartment = (deptId) => {
+  const department = departments.find((dept) => dept.id === deptId);
+  if (!department) {
+    console.error(`Department with id ${deptId} not found`);
+    return;
+  }
+
+  document.title = `${department.name} · Workplace Operations Dashboard`;
+  renderStats(department);
+  renderTrend(department);
+  renderList(projectsList, department.projects.items);
+  renderList(highlightsList, department.highlights.items);
+  renderMeetings(department);
+  setContexts(department);
+};
+
+const handleSelectChange = (event) => {
+  renderDepartment(event.target.value);
+};
+
+const init = () => {
+  populateDepartmentSelect();
+  departmentSelect.addEventListener("change", handleSelectChange);
+  const defaultDepartment = departments[0];
+  departmentSelect.value = defaultDepartment.id;
+  renderDepartment(defaultDepartment.id);
+};
+
+init();


### PR DESCRIPTION
## Summary
- add a newcomer-focused onboarding guide outlining architecture, data flow, and key concepts
- link the onboarding guide from the README to surface the documentation to future contributors

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d3efd0e2e88321b9fcdee150804697