### PR TITLE
Set up linting and formatting tooling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+coverage/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,33 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true
+  },
+  extends: ['eslint:recommended', 'plugin:import/recommended', 'prettier'],
+  plugins: ['import'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: ['.js']
+      }
+    }
+  },
+  rules: {
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true
+        }
+      }
+    ],
+    'no-console': 'warn'
+  }
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+coverage/
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "semi": true
+}

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+coverage/

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["stylelint-config-standard", "stylelint-config-prettier"],
+  "plugins": ["stylelint-order"],
+  "rules": {
+    "order/properties-alphabetical-order": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,41 @@ the codebase, data flow, and suggested next steps.
 * Tweak the palette or component styling in `assets/styles.css` to align with brand
   guidelines.
 
+
+## Code Quality Tooling
+
+This repository ships with shared linting and formatting tools to keep the codebase
+consistent:
+
+* **ESLint** checks the JavaScript modules in `src/` for logic and import issues.
+* **Prettier** enforces consistent formatting across JavaScript, CSS, Markdown, and JSON files.
+* **stylelint** validates CSS in `assets/` and any future style sheets.
+
+### Setup
+
+Install the development dependencies (Node.js 18+ recommended):
+
+```bash
+npm install
+```
+
+### Usage
+
+Run all linters:
+
+```bash
+npm run lint
+```
+
+Format the project in place:
+
+```bash
+npm run format
+```
+
+Each script can be run individually as well: `npm run lint:js` for JavaScript and
+`npm run lint:css` for CSS.
+
 ## Next Ideas
 
 * Wire up real APIs or CSV exports by replacing the static data module with fetch calls.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "bookish-chainsaw",
+  "version": "1.0.0",
+  "description": "A lightweight, framework-free dashboard that highlights the health of workplace teams. It summarises metrics, trend lines, upcoming meetings, and narrative highlights across Operations, Engineering, People Operations, and Workplace Experience departments.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "lint": "npm run lint:js && npm run lint:css",
+    "lint:js": "eslint \"src/**/*.js\" --max-warnings=0",
+    "lint:css": "stylelint \"**/*.css\"",
+    "format": "prettier --write \"{src,docs,assets}/**/*.{js,json,css,md}\" index.html"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "prettier": "^3.2.5",
+    "stylelint": "^16.6.1",
+    "stylelint-config-prettier": "^9.0.5",
+    "stylelint-config-standard": "^36.0.0",
+    "stylelint-order": "^6.0.4"
+  }
+}


### PR DESCRIPTION
## Summary
- add npm metadata with shared lint, format, and style scripts
- configure ESLint, Prettier, and stylelint for consistent code quality checks
- document the new tooling and commands in the README

## Testing
- npm install *(fails: registry returns 403 Forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f6cfa44c8321a99d4e27d18e62dc