### PR TITLE
Add offline data import flow and maintenance sample dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Workplace Operations Dashboard
+# Industrial Maintenance Dashboard
 
-A lightweight, framework-free dashboard that highlights the health of workplace teams. It
-summarises metrics, trend lines, upcoming meetings, and narrative highlights across
-Operations, Engineering, People Operations, and Workplace Experience departments.
+A lightweight, framework-free dashboard for plant maintenance leaders. It summarises crew
+throughput, backlog posture, predictive coverage, and safety activity across mechanical,
+electrical, and reliability disciplines—entirely offline.
 
 ## Getting Started
 
@@ -26,6 +26,19 @@ Then visit [http://localhost:8000](http://localhost:8000) and navigate to
 > **Tip:** The dashboard works entirely offline. None of the workflows above require internet
 > access, and all assets (fonts, data, styles) are bundled locally.
 
+## Refreshing Data Offline
+
+Maintenance analysts can load a JSON export (matching [`docs/data-contract.md`](docs/data-contract.md))
+without touching the code:
+
+1. From the sidebar, choose **Import offline data snapshot**.
+2. Pick a JSON file that follows the documented schema.
+3. The dashboard validates the payload, applies it instantly, and surfaces any warnings in the
+   banner while you remain offline.
+
+> The bundled dataset provides an industrial maintenance example for demo environments. Replace
+> it by importing your own CMMS export or by editing `src/data.js` directly.
+
 ## Project Structure
 
 ```
@@ -45,9 +58,9 @@ the codebase, data flow, and suggested next steps.
 ## Customising the Dashboard
 
 * Update `src/data.js` to reflect real metrics, project summaries, highlights, and
-  meetings from your workplace systems.
+  meetings from your maintenance systems—or import a JSON snapshot at runtime.
 * Adjust the cards or layout in `index.html` to match the views your stakeholders need
-  most (e.g. swap projects for staffing forecasts).
+  most (e.g. swap projects for shutdown readiness trackers).
 * Tweak the palette or component styling in `assets/styles.css` to align with brand
   guidelines.
 
@@ -59,19 +72,20 @@ workstations:
 
 * `npm run lint:js` executes `node --check` across the source, scripts, and test suites.
 * `npm run lint:css` scans every stylesheet to ensure no remote fonts or imports slip in.
-* `npm test` runs the lightweight DOM harness to confirm renderers and validation logic work.
+* `npm test` runs the lightweight DOM harness to confirm renderers, validation logic, and
+  offline guards work.
 * `npm run check` chains the linters and tests.
 
 ### Packaging for distribution
 
-Create a distributable archive that contains every offline asset:
+Create a distributable archive that contains the offline runtime (no development tooling):
 
 ```bash
 npm run package
 ```
 
-The command emits `dist/offline-dashboard.tar.gz` which can be copied to any disconnected
-environment.
+The command emits `dist/offline-dashboard.tar.gz` containing `index.html`, `assets/`, `src/`,
+the README, and the dataset contract. Copy the archive to any disconnected environment.
 
 ## Testing
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -145,6 +145,17 @@ body {
   box-shadow: var(--shadow-sm);
 }
 
+.card--summary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card--summary[data-state="empty"] .summary__body {
+  color: var(--color-muted);
+  font-style: italic;
+}
+
 .card--narrow {
   padding-bottom: 12px;
 }
@@ -181,6 +192,54 @@ body {
   color: var(--color-muted);
   font-size: 0.85rem;
   margin-top: 12px;
+}
+
+.ingest {
+  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ingest__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.ingest__input {
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px dashed var(--color-border);
+  background: var(--color-surface-alt);
+  font-family: inherit;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.ingest__input:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.ingest__status {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.ingest__status[data-state="success"] {
+  color: #047857;
+}
+
+.ingest__status[data-state="error"] {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.summary__body {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
 }
 
 .grid {

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,6 +1,6 @@
-# Workplace Operations Dashboard Onboarding Guide
+# Industrial Maintenance Dashboard Onboarding Guide
 
-Welcome to the Workplace Operations Dashboard project! This guide gives newcomers a
+Welcome to the Industrial Maintenance Dashboard project! This guide gives newcomers a
 quick orientation to the codebase, explains how data flows through the application,
 and highlights next areas to explore as you start contributing.
 
@@ -53,8 +53,9 @@ installation required—opening `index.html` in a modern browser will execute th
    * Drives the warnings banner and meta badges so data issues are surfaced to operators.
 
 5. **Entry point (`src/main.js`)**
-   * Imports the compiled `dataset` and simply calls `createDashboard(document, dataset)`.
-   * The minimal shell keeps browser code lean and maximises reusability in tests.
+   * Imports the compiled `dataset`, boots the dashboard, and listens for offline JSON imports.
+   * When an operator selects a file, the controller validates and applies the new snapshot
+     without reloading the page.
 
 6. **Validation layer (`src/validation.js`)**
    * Normalises any shape mismatches in the dataset so the UI never crashes on malformed
@@ -80,17 +81,17 @@ section and rebuilds the markup based on the new data set.
 * **Accessibility considerations** – Live regions, toggle controls, and chart fallbacks
   ensure the UI remains usable with assistive tech. Mirror this approach when adding
   features (e.g., always provide text alternatives and keyboard interactions).
-* **Offline guardrails** – The CSS and scripts lint checks guarantee no remote resources
-  are referenced. When adding assets, keep everything locally resolvable.
+* **Offline guardrails** – CSS validation and the offline assets test guarantee no remote
+  resources are referenced. When adding assets, keep everything locally resolvable.
 
 ## Suggested Next Steps for Contributors
 
 1. **Strengthen test coverage** – Expand the custom harness or integrate a headless
    browser to capture keyboard interaction flows and accessibility audits.
-2. **Build an offline data ingestion CLI** – Script the transformation from CSV/JSON
-   exports into the `dataset` module so updates remain reproducible.
-3. **Refine visual theming** – Consider theming hooks (e.g., CSS custom property overrides)
+2. **Refine visual theming** – Consider theming hooks (e.g., CSS custom property overrides)
    so downstream teams can reskin without editing component styles.
+3. **Expand offline data tooling** – If analysts prefer command-line workflows, add a helper
+   that converts CMMS exports into `src/data.js` to complement the runtime importer.
 4. **Explore print/export views** – An offline PDF or printable layout helps share
    snapshots during reviews in disconnected environments.
 5. **Codify contribution workflows** – Document branching, code review expectations, and

--- a/docs/TEST_HARNESS_PLAN.md
+++ b/docs/TEST_HARNESS_PLAN.md
@@ -1,7 +1,7 @@
 # Dashboard Test Harness Plan
 
 This document outlines how to introduce a lightweight automated test harness so UI and data
-changes to the Workplace Operations Dashboard can be validated before every release. The
+changes to the Industrial Maintenance Dashboard can be validated before every release. The
 approach favours minimal tooling, fast feedback, and tests that reflect how real users see the
 dashboard.
 

--- a/docs/data-contract.md
+++ b/docs/data-contract.md
@@ -61,11 +61,14 @@ interface ListItem {
 1. Update the meta block with the period and timestamp that correspond to the exported data.
 2. Replace the department array with the latest metrics and narratives from your systems.
 3. Run `npm run check` to let the offline validators confirm the structure is sound.
-4. Commit the updated `src/data.js` and regenerate the offline bundle with `npm run package`.
+4. Either:
+   * Import the JSON payload directly through the dashboard’s **Import offline data snapshot**
+     control, or
+   * Commit the updated `src/data.js` and regenerate the offline bundle with `npm run package`.
 
 ## Validation behaviour
 
 If optional fields are missing or arrays are empty, the UI falls back to friendly placeholder
-copy and the warnings banner displays the issues detected during boot. Validation never throws
-away data—it sanitises inputs to the closest safe defaults so the dashboard remains usable
-while surfacing problems for follow-up.
+copy and the warnings banner displays the issues detected during boot or import. Validation
+never throws away data—it sanitises inputs to the closest safe defaults so the dashboard remains
+usable while surfacing problems for follow-up.

--- a/index.html
+++ b/index.html
@@ -3,16 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Workplace Operations Dashboard</title>
+    <title>Industrial Maintenance Dashboard</title>
     <link rel="stylesheet" href="assets/styles.css" />
   </head>
   <body>
     <div class="dashboard">
       <header class="dashboard__header">
         <div>
-          <h1>Workplace Operations Dashboard</h1>
+          <h1>Industrial Maintenance Dashboard</h1>
           <p class="dashboard__subtitle">
-            A unified view of team health, project delivery, and operational focus.
+            A command center for plant maintenance leaders to track reliability, backlog,
+            and safety workstreams without needing an internet connection.
           </p>
         </div>
         <div class="dashboard__meta" aria-live="polite">
@@ -39,6 +40,18 @@
               Explore how each department is tracking against this week’s operational
               targets.
             </p>
+            <div class="ingest">
+              <label for="dataset-file" class="ingest__label">Import offline data snapshot</label>
+              <input
+                id="dataset-file"
+                class="ingest__input"
+                type="file"
+                accept="application/json,.json"
+              />
+              <p id="import-status" class="ingest__status" role="status" aria-live="polite">
+                Load a JSON export from your maintenance system to refresh the dashboard.
+              </p>
+            </div>
           </section>
 
           <section class="card card--narrow">
@@ -48,6 +61,18 @@
         </aside>
 
         <section class="dashboard__content">
+          <section
+            class="card card--summary"
+            id="department-summary-card"
+            data-state="empty"
+            aria-live="polite"
+          >
+            <h2>Maintenance Narrative</h2>
+            <p id="department-summary" class="summary__body">
+              Choose a maintenance group to see their weekly context.
+            </p>
+          </section>
+
           <section class="grid grid--stats" id="stats-grid"></section>
 
           <section class="card">

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -11,11 +11,9 @@ mkdir -p "$DIST"
 FILES=(
   index.html
   assets
-  docs
   src
-  scripts
   README.md
-  package.json
+  docs/data-contract.md
 )
 
 tar -czf "$ARCHIVE" -C "$ROOT" "${FILES[@]}"

--- a/src/data.js
+++ b/src/data.js
@@ -1,453 +1,381 @@
 export const dashboardMeta = {
-  reportingPeriod: "Week 32 · 2024",
-  lastUpdated: "Manual import · Aug 5, 2024 09:00",
-  refreshGuidance:
-    "Built for transparent operations. Import a new offline dataset to refresh the view."
+  reportingPeriod: "Maintenance Week 18 · 2024",
+  lastUpdated: "Manual import · May 6, 2024 06:30",
+  refreshGuidance: "Use the import control to load the latest CMMS export while offline."
 };
 
 export const departments = [
   {
     id: "all",
-    name: "All Departments",
-    summary: "Aggregate performance across operations, engineering, people, and workplace teams.",
+    name: "All Maintenance",
+    summary:
+      "Crew leaders kept preventive work on pace while trimming the emergency backlog. Reliability and safety partners are aligned on the boiler upgrade cutover slated for next week.",
     metrics: [
       {
-        label: "Projects On Track",
-        value: 18,
-        suffix: "/ 22",
-        trend: { label: "↑ 3", description: "vs last week" }
-      },
-      {
-        label: "Team Health Score",
-        value: 8.7,
-        suffix: "/ 10",
-        trend: { label: "↗ 0.4", description: "steady improvement" }
-      },
-      {
-        label: "Average Cycle Time",
-        value: 4.2,
-        suffix: " days",
-        trend: { label: "↓ 0.5", description: "faster than target" }
-      },
-      {
-        label: "Office Utilization",
-        value: 68,
+        label: "Preventive Compliance",
+        value: 92,
         suffix: "%",
-        trend: { label: "↑ 6", description: "after new seating plan" }
+        trend: { label: "↑ 4", description: "after planner stand-up reset routes" }
+      },
+      {
+        label: "Reactive Backlog",
+        value: 38,
+        suffix: " WO",
+        trend: { label: "↓ 11", description: "cleared weekend callouts" }
+      },
+      {
+        label: "Critical Asset Availability",
+        value: 97.5,
+        suffix: "%",
+        trend: { label: "↗ 0.8", description: "boiler redundancy restored" }
+      },
+      {
+        label: "Safety Observations Logged",
+        value: 54,
+        suffix: "",
+        trend: { label: "↑ 12", description: "crew-led audits" }
       }
     ],
     trend: {
-      context: "Story points delivered across all teams",
+      context: "Work orders closed per day across the site",
       datapoints: [
-        { label: "Mon", value: 54 },
-        { label: "Tue", value: 62 },
-        { label: "Wed", value: 71 },
-        { label: "Thu", value: 64 },
-        { label: "Fri", value: 78 },
-        { label: "Sat", value: 46 },
-        { label: "Sun", value: 38 }
+        { label: "Mon", value: 46 },
+        { label: "Tue", value: 58 },
+        { label: "Wed", value: 62 },
+        { label: "Thu", value: 57 },
+        { label: "Fri", value: 69 },
+        { label: "Sat", value: 34 },
+        { label: "Sun", value: 28 }
       ]
     },
     projects: {
-      context: "Top initiatives with the biggest operational impact",
+      context: "Plant-wide initiatives with executive visibility",
       items: [
         {
-          title: "Hybrid Work Enablement",
-          subtitle: "Deploy desk booking analytics to refine occupancy targets",
-          meta: "Phase 2 · 76% complete"
+          title: "Boiler Feedwater Retrofit",
+          subtitle: "Stage spare pump, perform insulation, and validate vibration limits",
+          meta: "Cutover window May 10"
         },
         {
-          title: "Incident Response Playbooks",
-          subtitle: "Cross-functional tabletop run-through with leadership",
-          meta: "Pilot sessions wrap Friday"
+          title: "Planner Playbook Rollout",
+          subtitle: "Standardise job plan templates and estimated hours across crews",
+          meta: "75% adoption"
         },
         {
-          title: "Benefits Enrollment Refresh",
-          subtitle: "Coordinated HR + Finance comms and knowledge base articles",
-          meta: "Launch comms Tuesday"
-        }
-      ]
-    },
-    highlights: {
-      context: "Wins and risks surfaced in leadership sync",
-      items: [
-        {
-          title: "Engineering shipped the deployment guardrails ahead of schedule",
-          subtitle: "Early telemetry shows 32% fewer rollbacks",
-          meta: "Reliability"
-        },
-        {
-          title: "Facilities resolved HVAC drift in the north annex",
-          subtitle: "Comfort scores climbed 12 points overnight",
-          meta: "Environment"
-        },
-        {
-          title: "People Ops onboarding cohort reached 95% satisfaction",
-          subtitle: "New check-in template surfaced friction points earlier",
-          meta: "People"
-        }
-      ]
-    },
-    meetings: [
-      {
-        title: "Operations Council",
-        description: "Weekly alignment on department OKRs",
-        time: "Monday · 9:00 – 10:00"
-      },
-      {
-        title: "Workplace Experience Deep Dive",
-        description: "Final seating map review for Q4",
-        time: "Tuesday · 14:30 – 15:15"
-      },
-      {
-        title: "People Ops Pulse",
-        description: "Review sentiment survey themes",
-        time: "Thursday · 11:00 – 11:45"
-      }
-    ]
-  },
-  {
-    id: "ops",
-    name: "Operations",
-    summary: "Ensuring end-to-end processes remain resilient and measurable.",
-    metrics: [
-      {
-        label: "On-Time Deliveries",
-        value: 96,
-        suffix: "%",
-        trend: { label: "↑ 2", description: "after vendor workshop" }
-      },
-      {
-        label: "Escalations",
-        value: 3,
-        suffix: " open",
-        trend: { label: "↓ 1", description: "major incidents resolved" }
-      },
-      {
-        label: "Budget Burn",
-        value: 51,
-        suffix: "%",
-        trend: { label: "↔", description: "mid-quarter" }
-      },
-      {
-        label: "Automation Coverage",
-        value: 64,
-        suffix: "%",
-        trend: { label: "↑ 8", description: "three new playbooks" }
-      }
-    ],
-    trend: {
-      context: "Fulfillment cycle time (hours per request)",
-      datapoints: [
-        { label: "Mon", value: 5.1 },
-        { label: "Tue", value: 4.8 },
-        { label: "Wed", value: 4.3 },
-        { label: "Thu", value: 4.6 },
-        { label: "Fri", value: 3.9 },
-        { label: "Sat", value: 4.4 },
-        { label: "Sun", value: 4.2 }
-      ]
-    },
-    projects: {
-      context: "Process optimizations nearing completion",
-      items: [
-        {
-          title: "Vendor SLA Dashboard",
-          subtitle: "Unified uptime visibility across logistics partners",
-          meta: "Go-live Friday"
-        },
-        {
-          title: "Auto-Renewal Policy",
-          subtitle: "Legal + Ops review to trim manual paperwork",
+          title: "Lockout/Tagout Refresh",
+          subtitle: "Audit panels and update laminated field guides",
           meta: "Sign-off pending"
         }
       ]
     },
     highlights: {
-      context: "Signals from the operations command center",
+      context: "Wins and watch items from the maintenance program review",
       items: [
         {
-          title: "Escalation runbook adoption hit 92% compliance",
-          subtitle: "Team ran two successful failover drills",
-          meta: "Operational Excellence"
+          title: "Oil analysis flagged bearing wear early",
+          subtitle: "Scheduled downtime avoided a 14-hour production stop",
+          meta: "Predictive"
         },
         {
-          title: "Warehouse IoT rollout expanded to 3 new sites",
-          subtitle: "Cycle time variance cut by 18%",
-          meta: "Automation"
+          title: "Confined space drill executed under target time",
+          subtitle: "EHS observers signed off on updated rescue kit staging",
+          meta: "Safety"
+        },
+        {
+          title: "Warehouse kitting achieved 98% accuracy",
+          subtitle: "Mechanics spent 40 fewer hours searching for parts",
+          meta: "Materials"
         }
       ]
     },
     meetings: [
       {
-        title: "Logistics Vendor Sync",
-        description: "Spot-check SLA performance",
-        time: "Wednesday · 13:00 – 13:45"
+        title: "Maintenance Readiness Huddle",
+        description: "Review daily crew assignments and plant constraints",
+        time: "Monday · 06:30 – 07:00"
       },
       {
-        title: "Quarterly Risk Review",
-        description: "Scenario modeling for peak season",
-        time: "Friday · 10:30 – 12:00"
+        title: "Reliability Steering Committee",
+        description: "Align on PdM alerts and risk-ranked assets",
+        time: "Wednesday · 11:30 – 12:15"
+      },
+      {
+        title: "Safety Walkdown",
+        description: "Cross-discipline review of boiler deck mitigations",
+        time: "Friday · 09:00 – 10:00"
       }
     ]
   },
   {
-    id: "eng",
-    name: "Engineering",
-    summary: "Delivering reliable product increments and platform improvements.",
+    id: "mechanical",
+    name: "Mechanical",
+    summary:
+      "Focus stayed on rotating equipment reliability and clearing overdue lubrication work. Gearbox rebuild prep is tracking, but alignment checks need extra support on second shift.",
     metrics: [
       {
-        label: "Deployment Success",
-        value: 99.1,
-        suffix: "%",
-        trend: { label: "↑ 1.2", description: "release guardrails live" }
-      },
-      {
-        label: "Velocity",
-        value: 420,
-        suffix: " pts",
-        trend: { label: "↑ 28", description: "productive spike" }
-      },
-      {
-        label: "Open Bugs",
-        value: 47,
-        suffix: "",
-        trend: { label: "↓ 12", description: "triage blitz" }
-      },
-      {
-        label: "Incident MTTR",
-        value: 42,
-        suffix: " mins",
-        trend: { label: "↓ 9", description: "faster mitigations" }
-      }
-    ],
-    trend: {
-      context: "Story points completed per day",
-      datapoints: [
-        { label: "Mon", value: 68 },
-        { label: "Tue", value: 74 },
-        { label: "Wed", value: 82 },
-        { label: "Thu", value: 71 },
-        { label: "Fri", value: 89 },
-        { label: "Sat", value: 36 },
-        { label: "Sun", value: 28 }
-      ]
-    },
-    projects: {
-      context: "Focus areas for the platform team",
-      items: [
-        {
-          title: "Observability Unification",
-          subtitle: "Migrating service metrics into the shared timeline view",
-          meta: "84% complete"
-        },
-        {
-          title: "API Rate Guardrails",
-          subtitle: "Progressive throttling + customer comms",
-          meta: "ETA next sprint"
-        },
-        {
-          title: "Mobile Shell Refresh",
-          subtitle: "Final QA for new offline persistence",
-          meta: "Ship window Wednesday"
-        }
-      ]
-    },
-    highlights: {
-      context: "Notable engineering callouts",
-      items: [
-        {
-          title: "Launch readiness checklist adopted squad-wide",
-          subtitle: "Defects at launch dipped 22%",
-          meta: "Quality"
-        },
-        {
-          title: "Error budget trending within safe limits",
-          subtitle: "SLO burn-down recovered after patch",
-          meta: "Reliability"
-        }
-      ]
-    },
-    meetings: [
-      {
-        title: "Architecture Review Board",
-        description: "Sequence-based caching proposal",
-        time: "Tuesday · 16:00 – 17:00"
-      },
-      {
-        title: "Incident Game Day",
-        description: "Chaos workflow validation",
-        time: "Thursday · 15:00 – 16:30"
-      }
-    ]
-  },
-  {
-    id: "people",
-    name: "People Operations",
-    summary: "Supporting employee engagement, hiring velocity, and retention.",
-    metrics: [
-      {
-        label: "Hiring Pipeline",
-        value: 42,
-        suffix: " open reqs",
-        trend: { label: "↗ 4", description: "marketing pipeline expanding" }
-      },
-      {
-        label: "Time to Fill",
-        value: 27,
-        suffix: " days",
-        trend: { label: "↓ 3", description: "streamlined interviews" }
-      },
-      {
-        label: "Attrition",
-        value: 6.4,
-        suffix: "%",
-        trend: { label: "↘ 0.8", description: "lowest this year" }
-      },
-      {
-        label: "Pulse Score",
-        value: 8.9,
-        suffix: "/ 10",
-        trend: { label: "↑ 0.6", description: "new manager rituals" }
-      }
-    ],
-    trend: {
-      context: "Offer acceptance rate per weekday",
-      datapoints: [
-        { label: "Mon", value: 78 },
-        { label: "Tue", value: 82 },
-        { label: "Wed", value: 74 },
-        { label: "Thu", value: 76 },
-        { label: "Fri", value: 88 },
-        { label: "Sat", value: 0 },
-        { label: "Sun", value: 0 }
-      ]
-    },
-    projects: {
-      context: "Employee experience efforts in flight",
-      items: [
-        {
-          title: "Manager Toolkit 2.0",
-          subtitle: "Peer coaching, conflict resolution, and salary narrative",
-          meta: "Workshop sprint this week"
-        },
-        {
-          title: "Global Onboarding Journey",
-          subtitle: "Localized benefits library launch",
-          meta: "Feedback review Friday"
-        }
-      ]
-    },
-    highlights: {
-      context: "Signals from the employee lifecycle",
-      items: [
-        {
-          title: "New hire NPS hit 76",
-          subtitle: "Welcome mentors credited for the lift",
-          meta: "Engagement"
-        },
-        {
-          title: "Benefits FAQ traffic tripled post campaign",
-          subtitle: "Self-serve answers reduced ticket queue by 18%",
-          meta: "Enablement"
-        }
-      ]
-    },
-    meetings: [
-      {
-        title: "Compensation Council",
-        description: "Finalize mid-year adjustments",
-        time: "Monday · 11:00 – 12:00"
-      },
-      {
-        title: "Talent Marketing Sync",
-        description: "Campaign retrospectives + next sprint",
-        time: "Wednesday · 15:30 – 16:15"
-      }
-    ]
-  },
-  {
-    id: "workplace",
-    name: "Workplace Experience",
-    summary: "Creating an environment where people do their best work.",
-    metrics: [
-      {
-        label: "Occupancy",
+        label: "Planned Work Ratio",
         value: 71,
         suffix: "%",
-        trend: { label: "↑ 5", description: "neighborhood pilot" }
+        trend: { label: "↑ 6", description: "better job kitting" }
       },
       {
-        label: "Support Tickets",
-        value: 18,
+        label: "Emergency Work Orders",
+        value: 4,
         suffix: " open",
-        trend: { label: "↘ 4", description: "self-serve kiosks live" }
+        trend: { label: "↓ 3", description: "stand-by millwright rotation" }
       },
       {
-        label: "Satisfaction",
-        value: 9.1,
-        suffix: "/ 10",
-        trend: { label: "↑ 0.7", description: "community activations" }
+        label: "Lubrication Compliance",
+        value: 88,
+        suffix: "%",
+        trend: { label: "↗ 5", description: "route consolidation complete" }
       },
       {
-        label: "Energy Use",
-        value: 84,
-        suffix: "% of baseline",
-        trend: { label: "↓ 6", description: "HVAC tuning complete" }
+        label: "Vibration Alerts",
+        value: 7,
+        suffix: "",
+        trend: { label: "↘ 2", description: "bearing replacements landed" }
       }
     ],
     trend: {
-      context: "Daily foot traffic (badge entries)",
+      context: "Average repair duration (hours)",
       datapoints: [
-        { label: "Mon", value: 420 },
-        { label: "Tue", value: 468 },
-        { label: "Wed", value: 492 },
-        { label: "Thu", value: 476 },
-        { label: "Fri", value: 388 },
-        { label: "Sat", value: 160 },
-        { label: "Sun", value: 120 }
+        { label: "Mon", value: 5.6 },
+        { label: "Tue", value: 4.3 },
+        { label: "Wed", value: 4.8 },
+        { label: "Thu", value: 4.1 },
+        { label: "Fri", value: 3.9 },
+        { label: "Sat", value: 4.5 },
+        { label: "Sun", value: 4.0 }
       ]
     },
     projects: {
-      context: "Facilities improvements in focus",
+      context: "Mechanical priorities in execution",
       items: [
         {
-          title: "Wayfinding Refresh",
-          subtitle: "Install dynamic signage and floor beacons",
-          meta: "Installations ongoing"
+          title: "Press Line Gearbox Rebuild",
+          subtitle: "Stage laser alignment tools and inspect coupling",
+          meta: "Tear-down Saturday"
         },
         {
-          title: "Wellness Room Expansion",
-          subtitle: "Ergonomic upgrades and booking automation",
-          meta: "Contractor review Thursday"
+          title: "Steam Trap Survey",
+          subtitle: "Thermal imaging sweep of north loop",
+          meta: "Fieldwork 60%"
+        },
+        {
+          title: "Hydraulic Hose Campaign",
+          subtitle: "Replace critical hoses with crimped assemblies",
+          meta: "12 of 18 complete"
         }
       ]
     },
     highlights: {
-      context: "Stories from the workplace experience team",
+      context: "Crew callouts from the mechanical superintendent",
       items: [
         {
-          title: "Community garden lunches filled every seat",
-          subtitle: "Employee chef program piloted successfully",
-          meta: "Engagement"
+          title: "Line 3 coupler change-out finished 2 hours early",
+          subtitle: "Rigging plan shaved downtime",
+          meta: "Schedule"
         },
         {
-          title: "Air quality monitoring alerts now integrated",
-          subtitle: "Facilities team receives push notifications",
-          meta: "Safety"
+          title: "Portable balancer training certified two new techs",
+          subtitle: "Enables weekend PdM coverage",
+          meta: "Skills"
         }
       ]
     },
     meetings: [
       {
-        title: "Space Planning Huddle",
-        description: "Re-balance quiet vs collaborative zones",
-        time: "Tuesday · 10:00 – 10:45"
+        title: "Millwright Toolbox Talk",
+        description: "Discuss lockout sequence updates and pinch point hazards",
+        time: "Tuesday · 06:10 – 06:30"
       },
       {
-        title: "Vendor Walkthrough",
-        description: "Review signage installation progress",
-        time: "Thursday · 09:30 – 10:15"
+        title: "Planner Hand-Off",
+        description: "Confirm parts availability for weekend shutdown",
+        time: "Thursday · 15:00 – 15:20"
+      }
+    ]
+  },
+  {
+    id: "electrical",
+    name: "Electrical & Instrumentation",
+    summary:
+      "The team prioritised MCC inspections and cleared nuisance trips on the packaging line. Instrument techs still need historian tags for the new flow meters before go-live.",
+    metrics: [
+      {
+        label: "PM Completion",
+        value: 95,
+        suffix: "%",
+        trend: { label: "↑ 3", description: "extra overtime window" }
+      },
+      {
+        label: "Control Cabinet Findings",
+        value: 12,
+        suffix: "",
+        trend: { label: "↗ 5", description: "thermal scans catching hot spots" }
+      },
+      {
+        label: "Breaker Trips",
+        value: 1,
+        suffix: "",
+        trend: { label: "↓ 2", description: "load balancing on line 5" }
+      },
+      {
+        label: "Calibration Backlog",
+        value: 6,
+        suffix: " loops",
+        trend: { label: "↘ 4", description: "loaned techs from utilities" }
+      }
+    ],
+    trend: {
+      context: "Protective relay tests completed per day",
+      datapoints: [
+        { label: "Mon", value: 3 },
+        { label: "Tue", value: 5 },
+        { label: "Wed", value: 4 },
+        { label: "Thu", value: 4 },
+        { label: "Fri", value: 6 },
+        { label: "Sat", value: 2 },
+        { label: "Sun", value: 1 }
+      ]
+    },
+    projects: {
+      context: "Electrical & instrumentation projects with open actions",
+      items: [
+        {
+          title: "MCC Infrared Survey",
+          subtitle: "Capture load imbalance data for panel 12",
+          meta: "Report due Thursday"
+        },
+        {
+          title: "Flow Meter Commissioning",
+          subtitle: "Validate scaling and historian tags",
+          meta: "Waiting on PI mapping"
+        },
+        {
+          title: "UPS Battery Replacement",
+          subtitle: "Swap cells on emergency lighting circuits",
+          meta: "8 of 14 panels"
+        }
+      ]
+    },
+    highlights: {
+      context: "Signals from electricians and instrument techs",
+      items: [
+        {
+          title: "Packaging PLC nuisance fault resolved",
+          subtitle: "Re-terminated loose IO block wiring",
+          meta: "Stability"
+        },
+        {
+          title: "Safety relay training completed for apprentices",
+          subtitle: "Now cleared for solo troubleshooting",
+          meta: "Training"
+        }
+      ]
+    },
+    meetings: [
+      {
+        title: "Power Distribution Review",
+        description: "Evaluate feeder loading against summer profile",
+        time: "Wednesday · 14:00 – 14:45"
+      },
+      {
+        title: "Instrumentation Stand-Up",
+        description: "Coordinate calibrations and spare transmitters",
+        time: "Friday · 07:30 – 07:50"
+      }
+    ]
+  },
+  {
+    id: "reliability",
+    name: "Reliability Engineering",
+    summary:
+      "Predictive program coverage expanded and the asset risk matrix was refreshed. The team is modelling spare motor lead times to avoid line stoppages during hurricane season.",
+    metrics: [
+      {
+        label: "PdM Coverage",
+        value: 78,
+        suffix: "%",
+        trend: { label: "↑ 7", description: "new ultrasound routes" }
+      },
+      {
+        label: "Failure Investigations",
+        value: 3,
+        suffix: " active",
+        trend: { label: "↔", description: "awaiting vendor reports" }
+      },
+      {
+        label: "Critical Spares Accuracy",
+        value: 94,
+        suffix: "%",
+        trend: { label: "↑ 4", description: "cycle counts reconciled" }
+      },
+      {
+        label: "Condition Alerts",
+        value: 9,
+        suffix: "",
+        trend: { label: "↘ 3", description: "addressed lube issues" }
+      }
+    ],
+    trend: {
+      context: "Risk-ranked assets reviewed each day",
+      datapoints: [
+        { label: "Mon", value: 8 },
+        { label: "Tue", value: 10 },
+        { label: "Wed", value: 9 },
+        { label: "Thu", value: 11 },
+        { label: "Fri", value: 12 },
+        { label: "Sat", value: 4 },
+        { label: "Sun", value: 3 }
+      ]
+    },
+    projects: {
+      context: "Reliability initiatives moving the risk needle",
+      items: [
+        {
+          title: "Asset Criticality Review",
+          subtitle: "Re-score packaging line drives with production",
+          meta: "Workshop Friday"
+        },
+        {
+          title: "Spare Motor Strategy",
+          subtitle: "Model lead time and carrying cost trade-offs",
+          meta: "Finance review next week"
+        },
+        {
+          title: "PdM Route Expansion",
+          subtitle: "Add ultrasound checks to ammonia compressors",
+          meta: "Relaunch Tuesday"
+        }
+      ]
+    },
+    highlights: {
+      context: "Notes from the reliability program board",
+      items: [
+        {
+          title: "MTBF on conveyors climbed to 124 days",
+          subtitle: "Root cause work orders closed the chronic jam",
+          meta: "Continuity"
+        },
+        {
+          title: "Digital twin pilot caught pump cavitation early",
+          subtitle: "Ops throttled flow before damage occurred",
+          meta: "Predictive"
+        }
+      ]
+    },
+    meetings: [
+      {
+        title: "PdM Analytics Review",
+        description: "Walk predictive trends with operations supervisors",
+        time: "Tuesday · 13:00 – 13:45"
+      },
+      {
+        title: "Spares Strategy Workshop",
+        description: "Align on stocking levels for hurricane readiness",
+        time: "Thursday · 10:00 – 11:00"
       }
     ]
   }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,46 @@
 import { dataset } from "./data.js";
 import { createDashboard } from "./dashboard.js";
 
-createDashboard(document, dataset);
+const controller = createDashboard(document, dataset);
+
+const fileInput = document.getElementById("dataset-file");
+const status = document.getElementById("import-status");
+
+const setStatus = (message, variant = "idle") => {
+  if (!status) {
+    return;
+  }
+  status.textContent = message;
+  if (variant === "idle") {
+    delete status.dataset.state;
+  } else {
+    status.dataset.state = variant;
+  }
+};
+
+if (fileInput) {
+  fileInput.addEventListener("change", async (event) => {
+    const target = event.target;
+    const [file] = target.files ?? [];
+
+    if (!file) {
+      return;
+    }
+
+    try {
+      setStatus(`Importing ${file.name}…`);
+      const text = await file.text();
+      const parsed = JSON.parse(text);
+      const result = controller.loadDataset(parsed);
+      setStatus(
+        `Loaded ${file.name}. Reporting period: ${result.meta.reportingPeriod}.`,
+        "success"
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      setStatus(`Unable to import dataset: ${message}.`, "error");
+    } finally {
+      target.value = "";
+    }
+  });
+}

--- a/tests/offline-assets.test.mjs
+++ b/tests/offline-assets.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+const TARGET_EXTENSIONS = new Set([".html", ".js", ".mjs"]);
+
+const gatherFiles = async (entry) => {
+  const results = [];
+  const entryStat = await stat(entry);
+  if (entryStat.isDirectory()) {
+    const entries = await readdir(entry);
+    for (const child of entries) {
+      const childPath = path.join(entry, child);
+      const childStat = await stat(childPath);
+      if (childStat.isDirectory()) {
+        results.push(...(await gatherFiles(childPath)));
+      } else if (TARGET_EXTENSIONS.has(path.extname(child))) {
+        results.push(childPath);
+      }
+    }
+  } else if (TARGET_EXTENSIONS.has(path.extname(entry))) {
+    results.push(entry);
+  }
+  return results;
+};
+
+const REMOTE_PATTERN = /https?:\/\//gi;
+
+test("runtime assets avoid remote network dependencies", async () => {
+  const roots = [path.join(ROOT, "index.html"), path.join(ROOT, "src"), path.join(ROOT, "tests")];
+  const files = [];
+  for (const root of roots) {
+    files.push(...(await gatherFiles(root)));
+  }
+
+  const offenders = [];
+  for (const file of files) {
+    const contents = await readFile(file, "utf8");
+    const matches = contents.match(REMOTE_PATTERN);
+    if (matches) {
+      offenders.push({ file: path.relative(ROOT, file), sample: matches[0] });
+    }
+  }
+
+  assert.equal(
+    offenders.length,
+    0,
+    offenders.length
+      ? `Remote URL detected in: ${offenders
+          .map((offender) => `${offender.file} (${offender.sample})`)
+          .join(", ")}`
+      : ""
+  );
+});

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -30,6 +30,8 @@ const buildDocument = () => {
   register("#highlights-list", new MockElement("ul", document));
   register("#highlights-context", new MockElement("span", document));
   register("#meetings-list", new MockElement("ul", document));
+  register("#department-summary", new MockElement("p", document));
+  register("#department-summary-card", new MockElement("section", document));
   register("#data-warnings", new MockElement("aside", document));
   register("#reporting-period", new MockElement("span", document));
   register("#last-updated", new MockElement("span", document));
@@ -64,4 +66,39 @@ test("validation provides sane fallbacks", () => {
   assert.ok(result.warnings.length > 0, "warnings should be emitted for incomplete data");
   assert.equal(result.departments[0].metrics.length, 0);
   assert.equal(result.meta.reportingPeriod, "Not specified");
+});
+
+test("loadDataset applies new snapshot and preserves selection where possible", () => {
+  const document = buildDocument();
+  const controller = createDashboard(document, dataset);
+
+  const select = document.querySelector("#department-select");
+  select.value = dataset.departments[0].id;
+
+  const newDataset = {
+    meta: {
+      reportingPeriod: "Week 20 · 2024",
+      lastUpdated: "Manual import · May 12, 2024",
+      refreshGuidance: "Test guidance"
+    },
+    departments: [
+      {
+        id: "demo",
+        name: "Demo Department",
+        summary: "Summary copy for demo dataset.",
+        metrics: [],
+        trend: { context: "", datapoints: [] },
+        projects: { context: "", items: [] },
+        highlights: { context: "", items: [] },
+        meetings: []
+      }
+    ]
+  };
+
+  controller.loadDataset(newDataset);
+
+  assert.equal(document.querySelector("#reporting-period").textContent, "Week 20 · 2024");
+  assert.equal(document.querySelector("#department-summary").textContent, "Summary copy for demo dataset.");
+  assert.equal(select.value, "demo");
+  controller.teardown();
 });


### PR DESCRIPTION
## Summary
- add an offline JSON import control and controller support for reloading datasets at runtime
- surface each department narrative in the UI and theme the dashboard for industrial maintenance use cases
- refresh the bundled dataset, packaging script, and docs to reflect maintenance operations and tighter offline guardrails
- extend automated tests with an offline asset scan and coverage for the new loadDataset path

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4019a4fb08321bcd8d28e7ec00e4b