### PR TITLE
Implement performance, validation, and importer hardening

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+max_line_length = 100
+
+[*.md]
+max_line_length = 120

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ without touching the code:
 3. The dashboard validates the payload, applies it instantly, and surfaces any warnings in the
    banner while you remain offline.
 
+> Snapshots up to **2 MB** import without blocking the UI. Larger files are rejected with a
+> friendly error so the page stays responsive. Break huge exports into multiple departments or
+> trim unused fields before retrying.
+
 > The bundled dataset provides an industrial maintenance example for demo environments. Replace
 > it by importing your own CMMS export or by editing `src/data.js` directly.
 
@@ -72,9 +76,13 @@ workstations:
 
 * `npm run lint:js` executes `node --check` across the source, scripts, and test suites.
 * `npm run lint:css` scans every stylesheet to ensure no remote fonts or imports slip in.
-* `npm test` runs the lightweight DOM harness to confirm renderers, validation logic, and
-  offline guards work.
+* `npm test` runs the lightweight DOM harness to confirm renderers, validation logic, importer
+  guards, and offline behaviour work—even for large datasets.
 * `npm run check` chains the linters and tests.
+
+Performance instrumentation is available via the browser console: look for
+`dashboard:boot`, `dashboard:load`, and `dataset-import:*` measurements to compare tuning
+iterations.
 
 ### Packaging for distribution
 
@@ -85,7 +93,9 @@ npm run package
 ```
 
 The command emits `dist/offline-dashboard.tar.gz` containing `index.html`, `assets/`, `src/`,
-the README, and the dataset contract. Copy the archive to any disconnected environment.
+the README, and the dataset contract. Copy the archive to any disconnected environment. A
+SHA-256 checksum prints at the end of the run so operators can verify integrity before
+distribution.
 
 ## Testing
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -54,13 +54,16 @@ installation required—opening `index.html` in a modern browser will execute th
 
 5. **Entry point (`src/main.js`)**
    * Imports the compiled `dataset`, boots the dashboard, and listens for offline JSON imports.
+   * Guards against multi-megabyte snapshots, defers JSON parsing off the critical path, and logs
+     performance timings (`dataset-import:*`) for future profiling work.
    * When an operator selects a file, the controller validates and applies the new snapshot
      without reloading the page.
 
 6. **Validation layer (`src/validation.js`)**
    * Normalises any shape mismatches in the dataset so the UI never crashes on malformed
      input.
-   * Emits human-readable warnings that appear in the dashboard banner.
+   * Enforces the documented schema version, caps array sizes (departments, metrics, trend points),
+     and emits human-readable warnings that appear in the dashboard banner.
 
 7. **Testing harness (`tests/`)**
    * Provides a bespoke mock DOM implementation so renderers can be exercised without

--- a/docs/data-contract.md
+++ b/docs/data-contract.md
@@ -6,12 +6,13 @@ below so the validation layer can provide meaningful feedback instead of failing
 
 ```ts
 interface DashboardDataset {
+  schemaVersion: 1;             // Increment when the contract changes
   meta: {
     reportingPeriod: string;     // e.g. "Week 32 · 2024"
     lastUpdated: string;         // e.g. "Manual import · Aug 5, 2024 09:00"
     refreshGuidance: string;     // Guidance displayed in the footer
   };
-  departments: Department[];
+  departments: Department[];    // Up to 50 entries per snapshot
 }
 
 interface Department {
@@ -32,21 +33,21 @@ interface Department {
     datapoints: Array<{
       label: string;             // Typically day of week
       value: number;             // Numeric value plotted in the chart and table
-    }>;
+    }>;                         // Capped at 366 points (roughly one year of daily data)
   };
   projects: {
     context: string;
-    items: Array<ListItem>;
+    items: Array<ListItem>;      // Capped at 200 items to keep rendering fast
   };
   highlights: {
     context: string;
-    items: Array<ListItem>;
+    items: Array<ListItem>;      // Capped at 200 items
   };
   meetings: Array<{
     title: string;
     description: string;
     time: string;
-  }>;
+  }>;                           // Capped at 100 upcoming meetings
 }
 
 interface ListItem {

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -19,3 +19,6 @@ FILES=(
 tar -czf "$ARCHIVE" -C "$ROOT" "${FILES[@]}"
 
 echo "Offline bundle created at $ARCHIVE"
+if command -v sha256sum >/dev/null 2>&1; then
+  echo "SHA-256: $(sha256sum "$ARCHIVE" | awk '{print $1}')"
+fi

--- a/src/data.js
+++ b/src/data.js
@@ -382,6 +382,7 @@ export const departments = [
 ];
 
 export const dataset = {
+  schemaVersion: 1,
   meta: dashboardMeta,
   departments
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,25 +1,73 @@
 import { dataset } from "./data.js";
 import { createDashboard } from "./dashboard.js";
 
-const controller = createDashboard(document, dataset);
+const MAX_IMPORT_BYTES = 2 * 1024 * 1024; // 2 MB guard for offline snapshots
 
-const fileInput = document.getElementById("dataset-file");
-const status = document.getElementById("import-status");
+const supportsPerformanceMarks =
+  typeof performance !== "undefined" &&
+  typeof performance.mark === "function" &&
+  typeof performance.measure === "function";
 
-const setStatus = (message, variant = "idle") => {
-  if (!status) {
+const mark = (name, state) => {
+  if (!supportsPerformanceMarks) {
     return;
   }
-  status.textContent = message;
-  if (variant === "idle") {
-    delete status.dataset.state;
-  } else {
-    status.dataset.state = variant;
+
+  performance.mark(`${name}:${state}`);
+};
+
+const measure = (name, startState, endState) => {
+  if (!supportsPerformanceMarks) {
+    return;
+  }
+
+  const start = `${name}:${startState}`;
+  const end = `${name}:${endState}`;
+  performance.measure(name, start, end);
+  if (typeof performance.clearMarks === "function") {
+    performance.clearMarks(start);
+    performance.clearMarks(end);
+  }
+  if (typeof performance.clearMeasures === "function") {
+    performance.clearMeasures(name);
   }
 };
 
-if (fileInput) {
-  fileInput.addEventListener("change", async (event) => {
+const parseJsonAsync = (text) =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => {
+      try {
+        resolve(JSON.parse(text));
+      } catch (error) {
+        reject(error);
+      }
+    }, 0);
+  });
+
+const formatBytes = (bytes) => {
+  const megabytes = bytes / (1024 * 1024);
+  return `${megabytes.toFixed(megabytes >= 10 ? 0 : 1)} MB`;
+};
+
+export const initializeDashboard = (documentRef = document, initialDataset = dataset) => {
+  const controller = createDashboard(documentRef, initialDataset);
+
+  const fileInput = documentRef.getElementById("dataset-file");
+  const status = documentRef.getElementById("import-status");
+
+  const setStatus = (message, variant = "idle") => {
+    if (!status) {
+      return;
+    }
+    status.textContent = message;
+    if (variant === "idle") {
+      delete status.dataset.state;
+    } else {
+      status.dataset.state = variant;
+    }
+  };
+
+  const handleChange = async (event) => {
     const target = event.target;
     const [file] = target.files ?? [];
 
@@ -27,11 +75,30 @@ if (fileInput) {
       return;
     }
 
+    if (file.size > MAX_IMPORT_BYTES) {
+      setStatus(
+        `Dataset is too large (${formatBytes(file.size)}). Maximum supported size is ${formatBytes(
+          MAX_IMPORT_BYTES
+        )}.`,
+        "error"
+      );
+      target.value = "";
+      return;
+    }
+
     try {
       setStatus(`Importing ${file.name}…`);
+      mark("dataset-import", "read-start");
       const text = await file.text();
-      const parsed = JSON.parse(text);
+      mark("dataset-import", "read-end");
+      mark("dataset-import", "parse-start");
+      const parsed = await parseJsonAsync(text);
+      mark("dataset-import", "parse-end");
       const result = controller.loadDataset(parsed);
+      mark("dataset-import", "apply-end");
+      measure("dataset-import:read", "read-start", "read-end");
+      measure("dataset-import:parse", "parse-start", "parse-end");
+      measure("dataset-import:total", "read-start", "apply-end");
       setStatus(
         `Loaded ${file.name}. Reporting period: ${result.meta.reportingPeriod}.`,
         "success"
@@ -42,5 +109,26 @@ if (fileInput) {
     } finally {
       target.value = "";
     }
-  });
+  };
+
+  if (fileInput) {
+    fileInput.addEventListener("change", handleChange);
+  }
+
+  return {
+    controller,
+    teardown() {
+      if (fileInput) {
+        fileInput.removeEventListener("change", handleChange);
+      }
+      if (typeof controller.teardown === "function") {
+        controller.teardown();
+      }
+    },
+    setStatus
+  };
+};
+
+if (typeof document !== "undefined" && typeof document.getElementById === "function") {
+  initializeDashboard();
 }

--- a/tests/import-errors.test.mjs
+++ b/tests/import-errors.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { initializeDashboard } from "../src/main.js";
+import { buildDocument } from "./support/build-document.js";
+
+test("oversized dataset import surfaces error state", async () => {
+  const document = buildDocument();
+  globalThis.document = document;
+
+  const status = document.querySelector("#import-status");
+  const input = document.querySelector("#dataset-file");
+
+  const fakeFile = {
+    name: "too-big.json",
+    size: 3 * 1024 * 1024,
+    async text() {
+      return "{}";
+    }
+  };
+
+  input.files = [fakeFile];
+
+  const { teardown } = initializeDashboard(document);
+
+  const handler = input.listeners.get("change");
+  await handler({ target: input, type: "change" });
+
+  assert.match(status.textContent, /Dataset is too large/);
+  assert.equal(status.dataset.state, "error");
+
+  teardown();
+  delete globalThis.document;
+});
+
+test("invalid JSON import reports failure", async () => {
+  const document = buildDocument();
+  globalThis.document = document;
+
+  const status = document.querySelector("#import-status");
+  const input = document.querySelector("#dataset-file");
+
+  const fakeFile = {
+    name: "broken.json",
+    size: 1024,
+    async text() {
+      return "{not valid}";
+    }
+  };
+
+  input.files = [fakeFile];
+
+  const { teardown } = initializeDashboard(document);
+
+  const handler = input.listeners.get("change");
+  await handler({ target: input, type: "change" });
+
+  assert.match(status.textContent, /Unable to import dataset/);
+  assert.equal(status.dataset.state, "error");
+
+  teardown();
+  delete globalThis.document;
+});

--- a/tests/large-dataset.test.mjs
+++ b/tests/large-dataset.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { createDashboard } from "../src/dashboard.js";
+import { buildDocument } from "./support/build-document.js";
+
+test("dashboard handles oversized sections with capped rendering", () => {
+  const document = buildDocument();
+  const dataset = {
+    schemaVersion: 1,
+    meta: { stray: true },
+    extraTopLevel: true,
+    departments: [
+      {
+        id: "bulk",
+        name: "Bulk",
+        summary: "",
+        metrics: [],
+        trend: { context: "", datapoints: [] },
+        projects: {
+          context: "",
+          items: Array.from({ length: 220 }, (_, index) => ({
+            title: `Project ${index}`,
+            subtitle: "",
+            meta: "",
+            unknown: true
+          }))
+        },
+        highlights: {
+          context: "",
+          items: [],
+          unexpected: true
+        },
+        meetings: [],
+        mystery: true
+      }
+    ]
+  };
+
+  const controller = createDashboard(document, dataset);
+
+  const projectsList = document.querySelector("#projects-list");
+  assert.equal(projectsList.children.length, 200, "projects should be limited to 200 items");
+
+  const warningsRegion = document.querySelector("#data-warnings");
+  assert.ok(warningsRegion.children.length > 0, "warnings should render when issues detected");
+  const warningList = warningsRegion.children[0];
+  assert.ok(warningList.children.length <= 6, "warnings should be truncated with summary");
+  assert.equal(warningsRegion.getAttribute("data-state"), "visible");
+  controller.teardown();
+});

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -2,44 +2,7 @@ import assert from "node:assert/strict";
 import { dataset } from "../src/data.js";
 import { createDashboard } from "../src/dashboard.js";
 import { validateDataset } from "../src/validation.js";
-import { createMockDocument, MockElement } from "./support/mock-document.js";
-
-const buildDocument = () => {
-  const document = createMockDocument();
-
-  const register = (selector, element) => document.register(selector, element);
-
-  const trendContainer = register(".trend", new MockElement("div", document));
-  const trendChart = new MockElement("div", document);
-  trendChart.dataset.view = "chart";
-  register("#trend-chart", trendChart);
-
-  const trendTable = new MockElement("table", document);
-  const trendTableBody = new MockElement("tbody", document);
-  trendTable.append(trendTableBody);
-  register("#trend-table", trendTable);
-  register("#trend-table tbody", trendTableBody);
-
-  trendContainer.append(trendChart, trendTable);
-
-  register("#department-select", new MockElement("select", document));
-  register("#stats-grid", new MockElement("div", document));
-  register("#trend-context", new MockElement("span", document));
-  register("#projects-list", new MockElement("ul", document));
-  register("#projects-context", new MockElement("span", document));
-  register("#highlights-list", new MockElement("ul", document));
-  register("#highlights-context", new MockElement("span", document));
-  register("#meetings-list", new MockElement("ul", document));
-  register("#department-summary", new MockElement("p", document));
-  register("#department-summary-card", new MockElement("section", document));
-  register("#data-warnings", new MockElement("aside", document));
-  register("#reporting-period", new MockElement("span", document));
-  register("#last-updated", new MockElement("span", document));
-  register("#refresh-guidance", new MockElement("p", document));
-  register("#trend-toggle", new MockElement("button", document));
-
-  return document;
-};
+import { buildDocument } from "./support/build-document.js";
 
 test("dashboard renders default department data", () => {
   const document = buildDocument();
@@ -66,6 +29,17 @@ test("validation provides sane fallbacks", () => {
   assert.ok(result.warnings.length > 0, "warnings should be emitted for incomplete data");
   assert.equal(result.departments[0].metrics.length, 0);
   assert.equal(result.meta.reportingPeriod, "Not specified");
+});
+
+test("validation injects placeholder department when none provided", () => {
+  const result = validateDataset({ meta: {}, departments: [] });
+  assert.equal(result.departments.length, 1);
+  assert.equal(result.departments[0].id, "dept-1");
+  assert.equal(
+    result.departments[0].name,
+    "Department 1",
+    "fallback department should use predictable name"
+  );
 });
 
 test("loadDataset applies new snapshot and preserves selection where possible", () => {

--- a/tests/support/build-document.js
+++ b/tests/support/build-document.js
@@ -1,0 +1,38 @@
+import { createMockDocument, MockElement } from "./mock-document.js";
+
+export const buildDocument = () => {
+  const document = createMockDocument();
+  const register = (selector, element) => document.register(selector, element);
+
+  const trendContainer = register(".trend", new MockElement("div", document));
+  const trendChart = new MockElement("div", document);
+  register("#trend-chart", trendChart);
+
+  const trendTable = new MockElement("table", document);
+  const trendTableBody = new MockElement("tbody", document);
+  trendTable.append(trendTableBody);
+  register("#trend-table", trendTable);
+  register("#trend-table tbody", trendTableBody);
+
+  trendContainer.append(trendChart, trendTable);
+
+  register("#department-select", new MockElement("select", document));
+  register("#stats-grid", new MockElement("div", document));
+  register("#trend-context", new MockElement("span", document));
+  register("#projects-list", new MockElement("ul", document));
+  register("#projects-context", new MockElement("span", document));
+  register("#highlights-list", new MockElement("ul", document));
+  register("#highlights-context", new MockElement("span", document));
+  register("#meetings-list", new MockElement("ul", document));
+  register("#department-summary", new MockElement("p", document));
+  register("#department-summary-card", new MockElement("section", document));
+  register("#data-warnings", new MockElement("aside", document));
+  register("#reporting-period", new MockElement("span", document));
+  register("#last-updated", new MockElement("span", document));
+  register("#refresh-guidance", new MockElement("p", document));
+  register("#trend-toggle", new MockElement("button", document));
+  register("#import-status", new MockElement("p", document));
+  register("#dataset-file", new MockElement("input", document));
+
+  return document;
+};

--- a/tests/support/mock-document.js
+++ b/tests/support/mock-document.js
@@ -30,6 +30,11 @@ class MockElement {
       return;
     }
 
+    if (node && node.isFragment) {
+      node.children.forEach((child) => this.appendChild(child));
+      return;
+    }
+
     if (typeof node === "string") {
       node = new MockTextNode(node, this.ownerDocument);
     }
@@ -107,6 +112,35 @@ class MockElement {
   }
 }
 
+class MockDocumentFragment {
+  constructor(document) {
+    this.ownerDocument = document;
+    this.children = [];
+    this.isFragment = true;
+  }
+
+  append(...nodes) {
+    nodes.forEach((node) => this.appendChild(node));
+  }
+
+  appendChild(node) {
+    if (node === null || node === undefined) {
+      return;
+    }
+
+    if (typeof node === "string") {
+      node = new MockTextNode(node, this.ownerDocument);
+    }
+
+    if (node.nodeType === 3) {
+      this.children.push(node);
+    } else {
+      node.parentNode = null;
+      this.children.push(node);
+    }
+  }
+}
+
 export const createMockDocument = () => {
   const elements = new Map();
 
@@ -120,8 +154,14 @@ export const createMockDocument = () => {
     querySelector(selector) {
       return elements.get(selector) ?? null;
     },
+    getElementById(id) {
+      return elements.get(`#${id}`) ?? null;
+    },
     createElement(tag) {
       return new MockElement(tag, document);
+    },
+    createDocumentFragment() {
+      return new MockDocumentFragment(document);
     },
     createTextNode(text) {
       return new MockTextNode(text, document);

--- a/tests/validation-unknown.test.mjs
+++ b/tests/validation-unknown.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { validateDataset } from "../src/validation.js";
+
+const oversizedDepartments = Array.from({ length: 60 }, (_, index) => ({
+  id: `dept-${index}`,
+  name: `Dept ${index}`,
+  summary: "",
+  metrics: Array.from({ length: 80 }, (__, metricIndex) => ({
+    label: `Metric ${metricIndex}`,
+    value: metricIndex,
+    suffix: "%",
+    trend: { label: "", description: "" },
+    extraMetricField: true
+  })),
+  trend: {
+    context: "",
+    datapoints: Array.from({ length: 400 }, (__, pointIndex) => ({
+      label: `Day ${pointIndex}`,
+      value: pointIndex,
+      unknown: true
+    })),
+    extraTrendField: true
+  },
+  projects: {
+    context: "",
+    items: Array.from({ length: 250 }, (__, itemIndex) => ({
+      title: `Project ${itemIndex}`,
+      subtitle: "",
+      meta: "",
+      other: true
+    })),
+    unexpected: true
+  },
+  highlights: {
+    context: "",
+    items: [],
+    unknown: true
+  },
+  meetings: Array.from({ length: 150 }, (__, meetingIndex) => ({
+    title: `Meeting ${meetingIndex}`,
+    description: "",
+    time: "",
+    somethingElse: true
+  })),
+  mysteryField: true
+}));
+
+test("validateDataset enforces limits and warns on unknown fields", () => {
+  const result = validateDataset({
+    schemaVersion: 99,
+    meta: { lastUpdated: "", refreshGuidance: "", reportingPeriod: "", stray: true },
+    departments: oversizedDepartments,
+    extraTopLevel: true
+  });
+
+  assert.equal(result.departments.length, 50, "departments should be capped at 50");
+  assert.ok(
+    result.departments.every((dept) => dept.metrics.length <= 50),
+    "metrics should be capped"
+  );
+  assert.ok(
+    result.departments.every((dept) => dept.trend.datapoints.length <= 366),
+    "trend datapoints should be capped"
+  );
+  assert.ok(
+    result.departments.every((dept) => dept.projects.items.length <= 200),
+    "project items should be capped"
+  );
+  assert.ok(
+    result.departments.every((dept) => dept.meetings.length <= 100),
+    "meetings should be capped"
+  );
+
+  const warningText = result.warnings.join(" ");
+  assert.match(warningText, /schemaVersion/);
+  assert.match(warningText, /unknown fields/);
+});


### PR DESCRIPTION
## Summary
- batch DOM updates, cache department lookups, and add boot/load/trend performance marks to speed up dashboard rendering
- harden dataset ingestion with async parsing, a 2 MB guard, schema version enforcement, and capped array sizes with clearer warnings
- expand the mock DOM harness and add importer, large dataset, validation, and fallback regression tests along with updated docs and packaging checksum

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4227821288321b030e4d1b0409b16